### PR TITLE
Add storybook-static to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 node_modules
+storybook-static


### PR DESCRIPTION
This project didn't ignore storybook-static before, which is the folder
Storybook build static site to.

It can be fixed by add storybook-static to .gitignore
